### PR TITLE
Ran into an issue where certain password characters would cause this …

### DIFF
--- a/reissueKey.sh
+++ b/reissueKey.sh
@@ -92,7 +92,7 @@ if [[ $OS -ge 9  ]]; then
 	log_user 0
 	spawn fdesetup changerecovery -personal
 	expect \"Enter a password for '/', or the recovery key:\"
-	send {${userPass}}
+	send \"${userPass}\"
 	send \r
 	log_user 1
 	expect eof


### PR DESCRIPTION
…to fail and expose the passwords in the logs. 