### PR TITLE
Update reissueKey.sh

### DIFF
--- a/reissueKey.sh
+++ b/reissueKey.sh
@@ -64,7 +64,7 @@ userName=$(/usr/bin/stat -f%Su /dev/console)
 OS=`/usr/bin/sw_vers -productVersion | awk -F. {'print $2'}`
 
 ## This first user check sees if the logged in account is already authorized with FileVault 2
-userCheck=`fdesetup list | awk -v usrN="$userName" -F, 'index($0, usrN) {print $1}'`
+userCheck=`fdesetup list | awk -v usrN="$userName" -F',' '$1 == usrN {print $1}'`
 if [ "${userCheck}" != "${userName}" ]; then
 	echo "This user is not a FileVault 2 enabled user."
 	exit 3


### PR DESCRIPTION
We expect to match only line 1 if `$userName` is set to `saitooo` and the following entries from `fdesetup list`:
```
saitooo,893572B2-6540-405E-8349-68FD015C9B8E
saitooo_test,B7F5DE70-1EA3-4F61-895C-B10F236A9E83
saitoadmin,EE1DF79E-D1F5-47AC-95DA-51647AAA5AD9
```

Instead it will match both `saitooo` and `saitooo_test`. Modifying the `awk` statement returns the expected output.